### PR TITLE
When not using the Basic authentication scheme then return credentials

### DIFF
--- a/lib/basic-auth-parser.js
+++ b/lib/basic-auth-parser.js
@@ -9,6 +9,7 @@ module.exports = function parse(auth) {
 
   result.scheme = parts[0];
   if (result.scheme !== 'Basic') {
+    result.credentials = parts[1];
     return result;
   }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.2",
   "main": "./lib/basic-auth-parser.js",
   "devDependencies": {
-    "vows": "0.6.x"
+    "vows": "0.8.x"
   },
   "scripts": {
     "test": "vows --spec"

--- a/test/basic-auth-parser-test.js
+++ b/test/basic-auth-parser-test.js
@@ -18,7 +18,8 @@ vows.describe('basic-auth-parser').addBatch({
       topic: basicAuthParser('Digest DEADC0FFEE'),
       'it should return parsed data': function (result) {
         assert.deepEqual(result, {
-          scheme: 'Digest'
+          scheme: 'Digest',
+          credentials: "DEADC0FFEE"
         });
       }
     },


### PR DESCRIPTION
This module does most of the heavy lifting for parsing the Authorization header for other schemes as well, such as for the 'Bearer' scheme used in JSON Web Tokens.  This modification allows a single parsing pass to retrieve either the basic auth or JSON Web Token.

I had to update Vows in order to run under Node v0.10.26.